### PR TITLE
Cap FluentAssertions to Open Licence

### DIFF
--- a/OleCf.Test/OleCf.Test.csproj
+++ b/OleCf.Test/OleCf.Test.csproj
@@ -19,7 +19,7 @@
     <None Include="TestFiles\Win81\f01b4d95cf55d32a.automaticDestinations-ms" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="7.0.0" />
+    <PackageReference Include="FluentAssertions" Version="[7.0.0,8.0.0)" />
     <PackageReference Include="NUnit" Version="4.3.2" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Due to the mess of [here](https://github.com/fluentassertions/fluentassertions/pull/2943). Protects against License Change 